### PR TITLE
fix(core): stabilize macOS installer flow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,6 @@
 
 # Go workspace file
 go.work
+
+# Local editor settings
+.zed/

--- a/cmd/commands.go
+++ b/cmd/commands.go
@@ -56,7 +56,7 @@ func startPrompt() {
 	for _, option := range selectedOptions {
 		installer := install.GetInstallerByTitle(option)
 		if installer != nil {
-			installer.Install()
+			install.RunInstaller(installer)
 		}
 	}
 	install.FinishAllInstallations()

--- a/cmd/install/docker.go
+++ b/cmd/install/docker.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
-	"os/user"
 	"time"
 )
 
@@ -33,8 +32,8 @@ func (d *DockerInstaller) Install() {
 		}
 	}()
 
-	// Install Docker using Homebrew
-	cmd := exec.Command("brew", "install", "docker")
+	// Install Docker Desktop using Homebrew cask
+	cmd := exec.Command("brew", "install", "--cask", "docker")
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 
@@ -50,7 +49,7 @@ func (d *DockerInstaller) Install() {
 
 	fmt.Printf("\r✅ Docker installed successfully.\n")
 
-	// Perform post-installation configurations
+	// Perform post-installation guidance
 	d.configureDocker()
 }
 
@@ -59,8 +58,9 @@ func (d *DockerInstaller) Title() string {
 }
 
 func (d *DockerInstaller) IsAlreadyInstalled() bool {
-	_, err := exec.LookPath("docker")
-	return err == nil
+	_, appErr := os.Stat("/Applications/Docker.app")
+	_, cliErr := exec.LookPath("docker")
+	return appErr == nil || cliErr == nil
 }
 
 func (d *DockerInstaller) Description() string {
@@ -72,26 +72,5 @@ func (d *DockerInstaller) Description() string {
 }
 
 func (d *DockerInstaller) configureDocker() {
-	fmt.Println("Performing post-installation configurations for Docker...")
-
-	// Get the user's username
-	currentUser, err := user.Current()
-	if err != nil {
-		fmt.Printf("\r❌ Error getting user information: %v\n", err)
-		return
-	}
-
-	// Add the user to the 'docker' group using dscl
-	cmd := exec.Command("dscl", ".", "-append", "/Groups/docker", "GroupMembership", currentUser.Username)
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
-
-	err = cmd.Run()
-
-	if err != nil {
-		fmt.Printf("\r❌ Error configuring Docker: %v\n", err)
-		return
-	}
-
-	fmt.Printf("\r✅ Docker configured successfully. Please restart your shell.\n")
+	fmt.Println("Docker Desktop installed. Open Docker.app once to finish initialization.")
 }

--- a/cmd/install/installer.go
+++ b/cmd/install/installer.go
@@ -7,6 +7,7 @@ import (
 	"os/exec"
 	"os/user"
 	"path/filepath"
+	"slices"
 	"strings"
 )
 
@@ -15,6 +16,12 @@ type Installer interface {
 	IsAlreadyInstalled() bool
 	Title() string
 	Description() string
+}
+
+type LifecycleInstaller interface {
+	Plan() string
+	Check() bool
+	Apply() error
 }
 
 var installers = []Installer{
@@ -62,7 +69,7 @@ func GetDescriptionByTitle(title string) string {
 func GetAlreadyInstalledTools() []string {
 	var alreadyInstalledTools []string
 	for _, i := range installers {
-		if !i.IsAlreadyInstalled() {
+		if !IsInstalled(i) {
 			continue
 		}
 		alreadyInstalledTools = append(alreadyInstalledTools, i.Title())
@@ -70,43 +77,109 @@ func GetAlreadyInstalledTools() []string {
 	return alreadyInstalledTools
 }
 
+func IsInstalled(i Installer) bool {
+	if lifecycleInstaller, ok := i.(LifecycleInstaller); ok {
+		return lifecycleInstaller.Check()
+	}
+	return i.IsAlreadyInstalled()
+}
+
+func RunInstaller(i Installer) {
+	if lifecycleInstaller, ok := i.(LifecycleInstaller); ok {
+		if lifecycleInstaller.Check() {
+			return
+		}
+		if err := lifecycleInstaller.Apply(); err != nil {
+			fmt.Printf("\r❌ Error installing %s: %v\n", i.Title(), err)
+		}
+		return
+	}
+	i.Install()
+}
+
 func FinishAllInstallations() {
+	fmt.Printf("\r✅ Installation steps finished.\n")
+
 	// Reload the shell configuration
 	err := reloadShellConfiguration()
 	if err != nil {
-		fmt.Printf("\r❌ Error reloading shell configuration: %v\n", err)
+		fmt.Printf("\r⚠️ Install completed, but shell configuration was not reloaded automatically: %v\n", err)
+		fmt.Printf("\r⚠️ Please run `source ~/.zshrc` (or restart your shell) to load changes.\n")
 		return
 	}
 
-	fmt.Printf("\r✅ All installations completed. Please restart your shell.\n")
+	fmt.Printf("\r✅ Shell configuration reloaded. Some tools may still require a new terminal session.\n")
 }
 
 func reloadShellConfiguration() error {
-	// Get the user's shell
-	shell := os.Getenv("SHELL")
-	// Path to the shell configuration file (.zshrc or .bashrc)
 	// Get the user's home directory
 	usr, err := user.Current()
 	if err != nil {
 		fmt.Printf("\r❌ Error getting user's home directory: %v\n", err)
 		return err
 	}
-	configFile := ""
-	switch {
-	case strings.Contains(shell, "zsh"):
-		configFile = filepath.Join(usr.HomeDir, ".zshrc")
-	case strings.Contains(shell, "bash"):
-		configFile = filepath.Join(usr.HomeDir, ".bashrc")
-	default:
-		fmt.Println("Warning: Unsupported shell detected. Please update your shell configuration manually.")
-		return errors.New("unsupported shell")
+
+	shell := currentShellPath()
+	if shell == "" {
+		return errors.New("unable to determine active shell")
 	}
-	// Determine the command to reload the shell based on the shell type
-	reloadCommand := "source"
+
+	configFile, err := shellConfigPath(usr.HomeDir, shell)
+	if err != nil {
+		fmt.Println("Warning: Unsupported shell detected. Please update your shell configuration manually.")
+		return err
+	}
+
 	// Execute the command to reload the shell configuration
-	cmd := exec.Command(os.Getenv("SHELL"), "-c", fmt.Sprintf("%s %s", reloadCommand, configFile))
+	cmd := exec.Command(shell, "-c", fmt.Sprintf("source %s", configFile))
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 
 	return cmd.Run()
+}
+
+func shellConfigPath(homeDir, shellPath string) (string, error) {
+	switch filepath.Base(shellPath) {
+	case "zsh":
+		return filepath.Join(homeDir, ".zshrc"), nil
+	case "bash":
+		return filepath.Join(homeDir, ".bashrc"), nil
+	default:
+		return "", errors.New("unsupported shell")
+	}
+}
+
+func currentShellPath() string {
+	if shell := os.Getenv("SHELL"); shell != "" {
+		return shell
+	}
+	for _, candidate := range []string{"zsh", "bash"} {
+		path, err := exec.LookPath(candidate)
+		if err == nil {
+			return path
+		}
+	}
+	return ""
+}
+
+func shellListedInEtcShells(shellPath string) bool {
+	content, err := os.ReadFile("/etc/shells")
+	if err != nil {
+		return false
+	}
+	allowed := parseShellList(string(content))
+	return slices.Contains(allowed, shellPath)
+}
+
+func parseShellList(content string) []string {
+	lines := strings.Split(content, "\n")
+	allowed := make([]string, 0, len(lines))
+	for _, line := range lines {
+		line = strings.TrimSpace(line)
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		allowed = append(allowed, line)
+	}
+	return allowed
 }

--- a/cmd/install/installer_test.go
+++ b/cmd/install/installer_test.go
@@ -1,0 +1,55 @@
+package install
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestParseShellList(t *testing.T) {
+	content := `
+# List of valid login shells
+/bin/bash
+/bin/zsh
+
+  /opt/homebrew/bin/zsh
+`
+
+	got := parseShellList(content)
+	want := []string{"/bin/bash", "/bin/zsh", "/opt/homebrew/bin/zsh"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("parseShellList() = %v, want %v", got, want)
+	}
+}
+
+func TestShellConfigPath(t *testing.T) {
+	home := "/Users/test"
+
+	tests := []struct {
+		name    string
+		shell   string
+		want    string
+		wantErr bool
+	}{
+		{name: "zsh", shell: "/bin/zsh", want: "/Users/test/.zshrc"},
+		{name: "bash", shell: "/bin/bash", want: "/Users/test/.bashrc"},
+		{name: "unsupported", shell: "/bin/fish", wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := shellConfigPath(home, tt.shell)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("expected error for shell %q", tt.shell)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tt.want {
+				t.Fatalf("shellConfigPath() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}

--- a/cmd/install/iterm2.go
+++ b/cmd/install/iterm2.go
@@ -37,7 +37,7 @@ func (i *Iterm2Installer) Install() {
 	}()
 
 	// Install iTerm2 using Homebrew
-	cmd := exec.Command("brew", "install", "iterm2")
+	cmd := exec.Command("brew", "install", "--cask", "iterm2")
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 

--- a/cmd/install/lifecycle_test.go
+++ b/cmd/install/lifecycle_test.go
@@ -1,0 +1,69 @@
+package install
+
+import "testing"
+
+type stubInstaller struct {
+	installed bool
+	installN  int
+	checkN    int
+	applyN    int
+}
+
+func (s *stubInstaller) Install() {
+	s.installN++
+	s.installed = true
+}
+
+func (s *stubInstaller) IsAlreadyInstalled() bool {
+	return s.installed
+}
+
+func (s *stubInstaller) Title() string {
+	return "stub"
+}
+
+func (s *stubInstaller) Description() string {
+	return "stub"
+}
+
+func (s *stubInstaller) Plan() string {
+	return "plan"
+}
+
+func (s *stubInstaller) Check() bool {
+	s.checkN++
+	return s.installed
+}
+
+func (s *stubInstaller) Apply() error {
+	s.applyN++
+	s.installed = true
+	return nil
+}
+
+func TestRunInstaller_UsesLifecycleWhenAvailable(t *testing.T) {
+	s := &stubInstaller{}
+
+	RunInstaller(s)
+
+	if s.checkN != 1 {
+		t.Fatalf("expected Check to be called once, got %d", s.checkN)
+	}
+	if s.applyN != 1 {
+		t.Fatalf("expected Apply to be called once, got %d", s.applyN)
+	}
+	if s.installN != 0 {
+		t.Fatalf("expected Install not to be called, got %d", s.installN)
+	}
+}
+
+func TestIsInstalled_UsesLifecycleCheck(t *testing.T) {
+	s := &stubInstaller{installed: true}
+
+	if !IsInstalled(s) {
+		t.Fatal("expected installer to be detected as installed")
+	}
+	if s.checkN != 1 {
+		t.Fatalf("expected Check to be called once, got %d", s.checkN)
+	}
+}

--- a/cmd/install/vscode.go
+++ b/cmd/install/vscode.go
@@ -32,7 +32,7 @@ func (v *VscodeInstaller) Install() {
 	}()
 
 	// Install Visual Studio Code using Homebrew
-	cmd := exec.Command("brew", "install", "visual-studio-code")
+	cmd := exec.Command("brew", "install", "--cask", "visual-studio-code")
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 

--- a/cmd/install/zsh.go
+++ b/cmd/install/zsh.go
@@ -1,63 +1,88 @@
 package install
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
 	"os/user"
 	"path/filepath"
+	"strings"
 	"time"
 )
 
 type ZshInstaller struct{}
 
+const zshrcManagedBlock = `
+# >>> go-env-prepare zsh >>>
+# Plugins installed by go-env-prepare
+if typeset -p plugins >/dev/null 2>&1; then
+  plugins+=(docker nvm go zsh-autosuggestions zsh-syntax-highlighting)
+  typeset -U plugins
+fi
+
+alias zc='code ~/.zshrc'
+alias rr='source ~/.zshrc && clear && echo "Zsh configuration reloaded."'
+# <<< go-env-prepare zsh <<<
+`
+
 func (z *ZshInstaller) Install() {
+	if z.Check() {
+		return
+	}
+
+	if err := z.Apply(); err != nil {
+		fmt.Printf("\r❌ Error installing Zsh: %v\n", err)
+	}
+}
+
+func (z *ZshInstaller) Plan() string {
+	return "Install Zsh, set it as default shell, install Oh My Zsh/plugins, and update .zshrc."
+}
+
+func (z *ZshInstaller) Check() bool {
+	return z.IsAlreadyInstalled() && z.isConfigured()
+}
+
+func (z *ZshInstaller) Apply() error {
 	fmt.Println("Checking Zsh installation...")
 
-	if z.IsAlreadyInstalled() {
-		return
-	}
-	fmt.Println("Zsh is not installed. Installing...")
+	if !z.IsAlreadyInstalled() {
+		fmt.Println("Zsh is not installed. Installing...")
 
-	// Display an animated hourglass loading indicator
-	done := make(chan bool)
-	go func() {
-		for {
-			select {
-			case <-done:
-				return
-			default:
-				fmt.Printf("\r⌛ Installing Zsh %s", loadingAnimation())
-				time.Sleep(300 * time.Millisecond)
+		// Display an animated hourglass loading indicator
+		done := make(chan bool)
+		go func() {
+			for {
+				select {
+				case <-done:
+					return
+				default:
+					fmt.Printf("\r⌛ Installing Zsh %s", loadingAnimation())
+					time.Sleep(300 * time.Millisecond)
+				}
 			}
+		}()
+
+		cmd := exec.Command("brew", "install", "zsh")
+		cmd.Stdout = os.Stdout
+		cmd.Stderr = os.Stderr
+
+		err := cmd.Run()
+		close(done)
+		if err != nil {
+			return err
 		}
-	}()
 
-	// Install Zsh using Homebrew
-	cmd := exec.Command("brew", "install", "zsh")
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
-
-	err := cmd.Run()
-
-	// Stop the loading animation
-	close(done)
-
-	if err != nil {
-		fmt.Printf("\r❌ Error installing Zsh: %v\n", err)
-		return
+		fmt.Printf("\r✅ Zsh installed successfully.\n")
+	} else {
+		fmt.Printf("\r✅ Zsh is already installed.\n")
 	}
 
-	fmt.Printf("\r✅ Zsh installed successfully.\n")
-
-	// Set Zsh as the default shell
 	z.setDefaultShell()
-
-	// Install Oh My Zsh
 	z.installOhMyZsh()
-
-	// Perform post-installation tasks for Zsh
 	z.postInstall()
+	return nil
 }
 
 func (z *ZshInstaller) Title() string {
@@ -77,47 +102,103 @@ func (z *ZshInstaller) IsAlreadyInstalled() bool {
 	return err == nil
 }
 
-// IsZshInstalled checks if Zsh is already installed
+// IsZshInstalled checks if Zsh is already installed.
 func IsZshInstalled() bool {
 	_, err := exec.LookPath("zsh")
 	return err == nil
 }
 
+func (z *ZshInstaller) isConfigured() bool {
+	usr, err := user.Current()
+	if err != nil {
+		return false
+	}
+
+	zshrcPath := filepath.Join(usr.HomeDir, ".zshrc")
+	content, err := os.ReadFile(zshrcPath)
+	if err != nil {
+		return false
+	}
+	if !strings.Contains(string(content), "# >>> go-env-prepare zsh >>>") {
+		return false
+	}
+
+	customPath, err := resolveZshCustomPath()
+	if err != nil {
+		return false
+	}
+
+	if _, err := os.Stat(filepath.Join(customPath, "plugins", "zsh-autosuggestions")); err != nil {
+		return false
+	}
+	if _, err := os.Stat(filepath.Join(customPath, "plugins", "zsh-syntax-highlighting")); err != nil {
+		return false
+	}
+
+	return true
+}
+
 func (z *ZshInstaller) setDefaultShell() {
 	fmt.Println("Setting Zsh as the default shell...")
 
-	// Get the user's home directory
+	path, err := detectValidZshShellPath()
+	if err != nil {
+		fmt.Printf("\r⚠️ Skipping default shell change: %v\n", err)
+		return
+	}
+
+	if os.Getenv("SHELL") == path {
+		fmt.Printf("\r✅ Zsh is already the active shell.\n")
+		return
+	}
+
+	cmd := exec.Command("chsh", "-s", path)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+
+	err = cmd.Run()
+	if err != nil {
+		fmt.Printf("\r❌ Error setting Zsh as the default shell: %v\n", err)
+		return
+	}
+
+	fmt.Printf("\r✅ Zsh set as the default shell.\n")
+}
+
+func detectValidZshShellPath() (string, error) {
+	zshPath, err := exec.LookPath("zsh")
+	if err != nil {
+		return "", errors.New("zsh binary not found")
+	}
+
+	if !shellListedInEtcShells(zshPath) {
+		return "", fmt.Errorf("%s is not listed in /etc/shells", zshPath)
+	}
+
+	return zshPath, nil
+}
+
+func (z *ZshInstaller) installOhMyZsh() {
+	fmt.Println("Installing Oh My Zsh...")
+
 	usr, err := user.Current()
 	if err != nil {
 		fmt.Printf("\r❌ Error getting user's home directory: %v\n", err)
 		return
 	}
 
-	// Update the shell to Zsh
-	cmd := exec.Command("chsh", "-s", "/usr/local/bin/zsh", usr.Username)
+	ohMyZshDir := filepath.Join(usr.HomeDir, ".oh-my-zsh")
+	if _, err := os.Stat(ohMyZshDir); err == nil {
+		fmt.Printf("\r✅ Oh My Zsh is already installed.\n")
+		return
+	}
+
+	cmd := exec.Command("sh", "-c", "$(curl -fsSL https://raw.github.com/ohmyzsh/ohmyzsh/master/tools/install.sh)")
+	cmd.Env = append(os.Environ(), "RUNZSH=no", "CHSH=no", "KEEP_ZSHRC=yes")
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 
 	err = cmd.Run()
-
-	if err != nil {
-		fmt.Printf("\r❌ Error setting Zsh as the default shell: %v\n", err)
-		return
-	}
-
-	fmt.Printf("\r✅ Zsh set as the default shell. Please restart your shell.\n")
-}
-
-func (z *ZshInstaller) installOhMyZsh() {
-	fmt.Println("Installing Oh My Zsh...")
-
-	// Install Oh My Zsh using the official script
-	cmd := exec.Command("sh", "-c", "$(curl -fsSL https://raw.github.com/ohmyzsh/ohmyzsh/master/tools/install.sh)")
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
-
-	err := cmd.Run()
-
 	if err != nil {
 		fmt.Printf("\r❌ Error installing Oh My Zsh: %v\n", err)
 		return
@@ -128,77 +209,96 @@ func (z *ZshInstaller) installOhMyZsh() {
 
 func (z *ZshInstaller) postInstall() {
 	fmt.Println("Performing post-installation tasks for Zsh...")
-
-	// Install Zsh plugins (e.g., zsh-autosuggestions, zsh-syntax-highlighting)
 	z.installZshPlugins()
-
-	// Update the .zshrc file with additional configurations
 	z.updateZshrc()
 }
 
 func (z *ZshInstaller) installZshPlugins() {
 	fmt.Println("Installing Zsh plugins...")
 
-	// Install zsh-autosuggestions
-	cmd := exec.Command("git", "clone", "https://github.com/zsh-users/zsh-autosuggestions.git", "$ZSH_CUSTOM/plugins/zsh-autosuggestions")
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
-	err := cmd.Run()
+	customPath, err := resolveZshCustomPath()
 	if err != nil {
-		fmt.Printf("\r❌ Error installing zsh-autosuggestions: %v\n", err)
+		fmt.Printf("\r❌ Error resolving ZSH_CUSTOM path: %v\n", err)
 		return
 	}
 
-	// Install zsh-syntax-highlighting
-	cmd = exec.Command("git", "clone", "https://github.com/zsh-users/zsh-syntax-highlighting.git", "$ZSH_CUSTOM/plugins/zsh-syntax-highlighting")
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
-	err = cmd.Run()
-	if err != nil {
-		fmt.Printf("\r❌ Error installing zsh-syntax-highlighting: %v\n", err)
+	pluginsDir := filepath.Join(customPath, "plugins")
+	if err := os.MkdirAll(pluginsDir, 0o755); err != nil {
+		fmt.Printf("\r❌ Error creating plugin directory: %v\n", err)
 		return
 	}
+
+	z.clonePluginIfMissing("https://github.com/zsh-users/zsh-autosuggestions.git", filepath.Join(pluginsDir, "zsh-autosuggestions"))
+	z.clonePluginIfMissing("https://github.com/zsh-users/zsh-syntax-highlighting.git", filepath.Join(pluginsDir, "zsh-syntax-highlighting"))
 
 	fmt.Printf("\r✅ Zsh plugins installed successfully.\n")
+}
+
+func (z *ZshInstaller) clonePluginIfMissing(repo, destination string) {
+	if _, err := os.Stat(destination); err == nil {
+		fmt.Printf("\r✅ Plugin already installed: %s\n", filepath.Base(destination))
+		return
+	}
+
+	cmd := exec.Command("git", "clone", repo, destination)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		fmt.Printf("\r❌ Error installing %s: %v\n", filepath.Base(destination), err)
+	}
+}
+
+func resolveZshCustomPath() (string, error) {
+	usr, err := user.Current()
+	if err != nil {
+		return "", err
+	}
+
+	customPath := os.Getenv("ZSH_CUSTOM")
+	if customPath == "" {
+		customPath = filepath.Join(usr.HomeDir, ".oh-my-zsh", "custom")
+	}
+
+	customPath = os.ExpandEnv(customPath)
+	if strings.HasPrefix(customPath, "~/") {
+		customPath = filepath.Join(usr.HomeDir, customPath[2:])
+	}
+	if !filepath.IsAbs(customPath) {
+		customPath = filepath.Join(usr.HomeDir, customPath)
+	}
+
+	return filepath.Clean(customPath), nil
 }
 
 func (z *ZshInstaller) updateZshrc() {
 	fmt.Println("Updating .zshrc file...")
 
-	// Get the user's home directory
 	usr, err := user.Current()
 	if err != nil {
 		fmt.Printf("\r❌ Error getting user's home directory: %v\n", err)
 		return
 	}
 
-	// Path to the .zshrc file
 	zshrcPath := filepath.Join(usr.HomeDir, ".zshrc")
+	content, err := os.ReadFile(zshrcPath)
+	if err != nil && !os.IsNotExist(err) {
+		fmt.Printf("\r❌ Error reading .zshrc file: %v\n", err)
+		return
+	}
 
-	// Append plugin configurations to the .zshrc file
-	pluginsConfig := `
-	# Zsh plugins
-	plugins=(
-		git
-		docker
-		nvm
-		go
-		zsh-autosuggestions
-		zsh-syntax-highlighting
-	)
+	if strings.Contains(string(content), "# >>> go-env-prepare zsh >>>") {
+		fmt.Printf("\r✅ .zshrc already contains go-env-prepare snippet.\n")
+		return
+	}
 
-	alias zc="code ~/.zshrc"
-	alias rr="source ~/.zshrc && clear && echo 'Zsh configuration reloaded.'
-
-	`
-	f, err := os.OpenFile(zshrcPath, os.O_APPEND|os.O_WRONLY, 0644)
+	f, err := os.OpenFile(zshrcPath, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0o644)
 	if err != nil {
 		fmt.Printf("\r❌ Error opening .zshrc file: %v\n", err)
 		return
 	}
 	defer f.Close()
 
-	_, err = f.WriteString(pluginsConfig)
+	_, err = f.WriteString(zshrcManagedBlock)
 	if err != nil {
 		fmt.Printf("\r❌ Error writing to .zshrc file: %v\n", err)
 		return

--- a/cmd/install/zsh_test.go
+++ b/cmd/install/zsh_test.go
@@ -1,0 +1,60 @@
+package install
+
+import (
+	"os/user"
+	"path/filepath"
+	"testing"
+)
+
+func TestResolveZshCustomPath_Default(t *testing.T) {
+	t.Setenv("ZSH_CUSTOM", "")
+
+	usr, err := user.Current()
+	if err != nil {
+		t.Fatalf("user.Current() error: %v", err)
+	}
+
+	got, err := resolveZshCustomPath()
+	if err != nil {
+		t.Fatalf("resolveZshCustomPath() error: %v", err)
+	}
+
+	want := filepath.Join(usr.HomeDir, ".oh-my-zsh", "custom")
+	if got != want {
+		t.Fatalf("resolveZshCustomPath() = %q, want %q", got, want)
+	}
+}
+
+func TestResolveZshCustomPath_ExpandEnv(t *testing.T) {
+	t.Setenv("CUSTOM_SUFFIX", "custom-dir")
+	t.Setenv("ZSH_CUSTOM", "/tmp/$CUSTOM_SUFFIX")
+
+	got, err := resolveZshCustomPath()
+	if err != nil {
+		t.Fatalf("resolveZshCustomPath() error: %v", err)
+	}
+
+	want := "/tmp/custom-dir"
+	if got != want {
+		t.Fatalf("resolveZshCustomPath() = %q, want %q", got, want)
+	}
+}
+
+func TestResolveZshCustomPath_ExpandTilde(t *testing.T) {
+	t.Setenv("ZSH_CUSTOM", "~/my-custom")
+
+	usr, err := user.Current()
+	if err != nil {
+		t.Fatalf("user.Current() error: %v", err)
+	}
+
+	got, err := resolveZshCustomPath()
+	if err != nil {
+		t.Fatalf("resolveZshCustomPath() error: %v", err)
+	}
+
+	want := filepath.Join(usr.HomeDir, "my-custom")
+	if got != want {
+		t.Fatalf("resolveZshCustomPath() = %q, want %q", got, want)
+	}
+}


### PR DESCRIPTION
## Ticket checklist
- [x] ticket-001.md
- [x] ticket-002.md
- [x] ticket-003.md
- [x] ticket-004.md
- [x] ticket-005.md
- [x] ticket-006.md
- [x] ticket-023.md

## What changed
- Ignored local `.zed/` settings in `.gitignore`.
- Introduced minimal installer lifecycle primitives (`Plan`, `Check`, `Apply`) via a new internal `LifecycleInstaller` interface while keeping existing CLI flow intact.
- Updated command execution flow to use lifecycle-aware installer runner.
- Improved completion messaging to separate install success from shell reload warning paths.
- Hardened Zsh installer behavior:
  - robust shell path detection for `chsh` using detected `zsh` binary and `/etc/shells` validation,
  - fixed `ZSH_CUSTOM` path resolution with env and `~` expansion,
  - made plugin install idempotent with existence checks and directory creation,
  - corrected `.zshrc` snippet (fixed quoting/aliases) and made snippet insertion idempotent via managed block markers,
  - made Oh My Zsh install non-interactive and idempotent.
- Switched GUI installers to proper Homebrew cask semantics:
  - iTerm2: `brew install --cask iterm2`
  - Visual Studio Code: `brew install --cask visual-studio-code`
  - Docker Desktop: `brew install --cask docker`
- Added unit tests for shell/path parsing and lifecycle behavior.

## Risks / compatibility notes
- Zsh installer `Check()` now evaluates configured state (binary + managed config/plugin state), so selecting Zsh may perform configuration steps even when zsh is already present.
- Docker installer now targets Docker Desktop cask and no longer attempts Linux-style docker-group mutation on macOS.
- Shell reload remains best-effort; CLI now reports warning-only if reload fails after successful installs.

## Validation output
```bash
$ go test ./...
?   	felipewom/go-env-prepare	[no test files]
?   	felipewom/go-env-prepare/cmd	[no test files]
ok  	felipewom/go-env-prepare/cmd/install	0.435s

$ go vet ./...
# (no output)
```
