### PR TITLE
feat(dynamic): implement manifest-driven execution core

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,10 @@
 ![MIT License](https://img.shields.io/badge/license-MIT-green)
 [![Buy Me a Coffee](https://img.shields.io/badge/buy%20me%20a%20coffee-donate-orange.svg)](https://buymeacoffee.com/felipewom)
 
-This is a CLI library that prepare your environment for different stacks, such as Node.js, Go, React, and .NET
-Your CLI Project is a command-line tool to help you set up development environments for various stacks.
+This is a CLI library that prepares your environment for different stacks, such as Node.js, Go, React, and .NET.
+It now supports both:
+- Interactive installer flow (`prepare`)
+- Declarative dynamic engine (`prepare plan|run|lint|lock`)
 
 ## Getting Started
 
@@ -51,6 +53,53 @@ make run
 ```
 
 Select the desired development tools when prompted.
+
+### Dynamic, Declarative Execution
+
+Use a manifest (`prepare.yaml` or `prepare.json`) to define profiles and tools. If no manifest is provided, builtin profiles are used.
+
+Example `prepare.yaml`:
+
+```yaml
+apiVersion: v1
+profile: fullstack
+profiles:
+  my-stack:
+    extends:
+      - backend
+    tools:
+      - nodejs
+```
+
+Commands:
+
+```bash
+# Build dependency-aware plan
+prepare plan --profile frontend
+
+# Show exact execution without changing machine
+prepare run --profile backend --dry-run
+
+# Load user manifest and execute
+prepare run --file prepare.yaml --profile my-stack
+
+# Validate profile syntax and semantics
+prepare lint --file prepare.yaml
+
+# Structured output for automation
+prepare run --profile fullstack --dry-run --json
+```
+
+Architecture summary:
+- Manifest loader/parser: resolves builtin + user profiles with inheritance.
+- Planner: expands dependencies and generates a topological execution order.
+- Executor: idempotent checks (`already_installed` skip), dry-run mode, and checkpoint resume (`--resume --state`).
+- Lock strategy: generates `prepare.lock.json` with pinned source/version metadata from the resolved plan.
+
+Migration notes from static installer flow:
+- `prepare` (no subcommand) keeps the existing interactive experience.
+- New workflows are additive under `prepare plan|run|lint|lock`.
+- Existing installer files under `cmd/install` are preserved for backward compatibility.
 
 ## Build
 

--- a/cmd/commands.go
+++ b/cmd/commands.go
@@ -117,10 +117,7 @@ func newLintCmd() *cobra.Command {
 		Use:   "lint",
 		Short: "Validate manifest syntax and semantic constraints",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if flags.ManifestPath == "" {
-				flags.ManifestPath = "prepare.yaml"
-			}
-			manifest, err := dynamic.LoadManifest(flags.ManifestPath)
+			manifest, err := loadManifestForFlags(flags)
 			if err != nil {
 				return err
 			}
@@ -178,17 +175,9 @@ func bindDynamicFlags(cmd *cobra.Command, flags *dynamicFlags) {
 }
 
 func buildPlan(flags *dynamicFlags) (dynamic.Plan, dynamic.Manifest, error) {
-	manifest := dynamic.Manifest{APIVersion: "v1", Profiles: map[string]dynamic.Profile{}}
-	if flags.ManifestPath != "" {
-		path, err := dynamic.DiscoverManifestPath(flags.ManifestPath)
-		if err == nil {
-			manifest, err = dynamic.LoadManifest(path)
-			if err != nil {
-				return dynamic.Plan{}, dynamic.Manifest{}, err
-			}
-		} else if !errors.Is(err, os.ErrNotExist) {
-			return dynamic.Plan{}, dynamic.Manifest{}, err
-		}
+	manifest, err := loadManifestForFlags(flags)
+	if err != nil {
+		return dynamic.Plan{}, dynamic.Manifest{}, err
 	}
 
 	catalog := dynamic.BuiltinCatalog()
@@ -205,6 +194,23 @@ func buildPlan(flags *dynamicFlags) (dynamic.Plan, dynamic.Manifest, error) {
 		return dynamic.Plan{}, dynamic.Manifest{}, err
 	}
 	return plan, manifest, nil
+}
+
+func loadManifestForFlags(flags *dynamicFlags) (dynamic.Manifest, error) {
+	manifest := dynamic.Manifest{APIVersion: "v1", Profiles: map[string]dynamic.Profile{}}
+	path, err := dynamic.DiscoverManifestPath(flags.ManifestPath)
+	if errors.Is(err, os.ErrNotExist) {
+		return manifest, nil
+	}
+	if err != nil {
+		return dynamic.Manifest{}, err
+	}
+
+	manifest, err = dynamic.LoadManifest(path)
+	if err != nil {
+		return dynamic.Manifest{}, err
+	}
+	return manifest, nil
 }
 
 func writeJSONFile(path string, v any) error {

--- a/cmd/commands.go
+++ b/cmd/commands.go
@@ -1,8 +1,12 @@
 package cmd
 
 import (
+	"encoding/json"
+	"errors"
 	"felipewom/go-env-prepare/cmd/install"
+	"felipewom/go-env-prepare/internal/dynamic"
 	"fmt"
+	"os"
 
 	"github.com/AlecAivazis/survey/v2"
 	"github.com/spf13/cobra"
@@ -12,11 +16,23 @@ type Commands struct {
 	RootCmd *cobra.Command
 }
 
+type dynamicFlags struct {
+	ManifestPath string
+	Profile      string
+	OutputJSON   bool
+	DryRun       bool
+	Resume       bool
+	StatePath    string
+	LockfilePath string
+}
+
 func NewCommands() *Commands {
-	rootCmd := &Commands{
-		RootCmd: newInstallCmd(),
-	}
+	rootCmd := &Commands{RootCmd: newInstallCmd()}
 	rootCmd.RootCmd.AddCommand(newVersionCmd())
+	rootCmd.RootCmd.AddCommand(newPlanCmd())
+	rootCmd.RootCmd.AddCommand(newRunCmd())
+	rootCmd.RootCmd.AddCommand(newLintCmd())
+	rootCmd.RootCmd.AddCommand(newLockCmd())
 	return rootCmd
 }
 
@@ -29,6 +45,178 @@ func newInstallCmd() *cobra.Command {
 			startPrompt()
 		},
 	}
+}
+
+func newPlanCmd() *cobra.Command {
+	flags := &dynamicFlags{}
+	cmd := &cobra.Command{
+		Use:   "plan",
+		Short: "Build an execution plan from builtin or manifest profiles",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			plan, _, err := buildPlan(flags)
+			if err != nil {
+				return err
+			}
+			if flags.OutputJSON {
+				return dynamic.PrintJSON(plan)
+			}
+			dynamic.PrintPlanHuman(plan)
+			return nil
+		},
+	}
+	bindDynamicFlags(cmd, flags)
+	return cmd
+}
+
+func newRunCmd() *cobra.Command {
+	flags := &dynamicFlags{}
+	cmd := &cobra.Command{
+		Use:   "run",
+		Short: "Execute profile plan with idempotency and optional dry-run",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			plan, _, err := buildPlan(flags)
+			if err != nil {
+				return err
+			}
+			executor := dynamic.NewExecutor()
+			result, runErr := executor.Run(plan, dynamic.ExecOptions{
+				DryRun:    flags.DryRun,
+				Resume:    flags.Resume,
+				StatePath: flags.StatePath,
+			})
+			if flags.OutputJSON {
+				if err := dynamic.PrintJSON(result); err != nil {
+					return err
+				}
+			} else {
+				dynamic.PrintExecutionHuman(result)
+			}
+			if runErr != nil {
+				return runErr
+			}
+			if flags.LockfilePath != "" {
+				lock := dynamic.BuildLockfile(plan)
+				if err := writeJSONFile(flags.LockfilePath, lock); err != nil {
+					return fmt.Errorf("write lockfile: %w", err)
+				}
+			}
+			return nil
+		},
+	}
+	bindDynamicFlags(cmd, flags)
+	cmd.Flags().BoolVar(&flags.DryRun, "dry-run", false, "Show execution result without mutating machine")
+	cmd.Flags().BoolVar(&flags.Resume, "resume", false, "Resume from previous checkpoint state")
+	cmd.Flags().StringVar(&flags.StatePath, "state", ".prepare.state.json", "Checkpoint state file path")
+	cmd.Flags().StringVar(&flags.LockfilePath, "lockfile", "prepare.lock.json", "Write lockfile after successful run")
+	return cmd
+}
+
+func newLintCmd() *cobra.Command {
+	flags := &dynamicFlags{}
+	cmd := &cobra.Command{
+		Use:   "lint",
+		Short: "Validate manifest syntax and semantic constraints",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if flags.ManifestPath == "" {
+				flags.ManifestPath = "prepare.yaml"
+			}
+			manifest, err := dynamic.LoadManifest(flags.ManifestPath)
+			if err != nil {
+				return err
+			}
+			catalog := dynamic.BuiltinCatalog()
+			profiles := dynamic.BuiltinProfiles()
+			if err := dynamic.ValidateManifest(manifest, catalog, profiles); err != nil {
+				if flags.OutputJSON {
+					_ = dynamic.PrintJSON(map[string]any{"valid": false, "error": err.Error()})
+				}
+				return err
+			}
+			if flags.OutputJSON {
+				return dynamic.PrintJSON(map[string]any{"valid": true})
+			}
+			fmt.Println("manifest is valid")
+			return nil
+		},
+	}
+	bindDynamicFlags(cmd, flags)
+	return cmd
+}
+
+func newLockCmd() *cobra.Command {
+	flags := &dynamicFlags{}
+	cmd := &cobra.Command{
+		Use:   "lock",
+		Short: "Generate a lockfile from the resolved execution plan",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			plan, _, err := buildPlan(flags)
+			if err != nil {
+				return err
+			}
+			if flags.LockfilePath == "" {
+				flags.LockfilePath = "prepare.lock.json"
+			}
+			if err := writeJSONFile(flags.LockfilePath, dynamic.BuildLockfile(plan)); err != nil {
+				return err
+			}
+			if flags.OutputJSON {
+				return dynamic.PrintJSON(map[string]any{"lockfile": flags.LockfilePath})
+			}
+			fmt.Printf("lockfile generated at %s\n", flags.LockfilePath)
+			return nil
+		},
+	}
+	bindDynamicFlags(cmd, flags)
+	cmd.Flags().StringVar(&flags.LockfilePath, "lockfile", "prepare.lock.json", "Lockfile path")
+	return cmd
+}
+
+func bindDynamicFlags(cmd *cobra.Command, flags *dynamicFlags) {
+	cmd.Flags().StringVarP(&flags.ManifestPath, "file", "f", "", "Manifest file path (prepare.yaml|prepare.json)")
+	cmd.Flags().StringVarP(&flags.Profile, "profile", "p", "", "Profile name to execute")
+	cmd.Flags().BoolVar(&flags.OutputJSON, "json", false, "Emit JSON output")
+}
+
+func buildPlan(flags *dynamicFlags) (dynamic.Plan, dynamic.Manifest, error) {
+	manifest := dynamic.Manifest{APIVersion: "v1", Profiles: map[string]dynamic.Profile{}}
+	if flags.ManifestPath != "" {
+		path, err := dynamic.DiscoverManifestPath(flags.ManifestPath)
+		if err == nil {
+			manifest, err = dynamic.LoadManifest(path)
+			if err != nil {
+				return dynamic.Plan{}, dynamic.Manifest{}, err
+			}
+		} else if !errors.Is(err, os.ErrNotExist) {
+			return dynamic.Plan{}, dynamic.Manifest{}, err
+		}
+	}
+
+	catalog := dynamic.BuiltinCatalog()
+	builtinProfiles := dynamic.BuiltinProfiles()
+	if err := dynamic.ValidateManifest(manifest, catalog, builtinProfiles); err != nil {
+		return dynamic.Plan{}, dynamic.Manifest{}, err
+	}
+	tools, err := dynamic.ResolveTools(manifest, flags.Profile, catalog, builtinProfiles)
+	if err != nil {
+		return dynamic.Plan{}, dynamic.Manifest{}, err
+	}
+	plan, err := dynamic.BuildPlan(tools, catalog)
+	if err != nil {
+		return dynamic.Plan{}, dynamic.Manifest{}, err
+	}
+	return plan, manifest, nil
+}
+
+func writeJSONFile(path string, v any) error {
+	b, err := jsonMarshalIndent(v)
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(path, b, 0o644)
+}
+
+func jsonMarshalIndent(v any) ([]byte, error) {
+	return json.MarshalIndent(v, "", "  ")
 }
 
 func newVersionCmd() *cobra.Command {

--- a/cmd/commands_test.go
+++ b/cmd/commands_test.go
@@ -1,0 +1,84 @@
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestBuildPlanAutoDiscoverySuccess(t *testing.T) {
+	tmp := t.TempDir()
+	manifest := "apiVersion: v1\nprofile: backend\n"
+	if err := os.WriteFile(filepath.Join(tmp, "prepare.yaml"), []byte(manifest), 0o644); err != nil {
+		t.Fatalf("write manifest: %v", err)
+	}
+
+	prevWD, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	defer func() { _ = os.Chdir(prevWD) }()
+	if err := os.Chdir(tmp); err != nil {
+		t.Fatalf("chdir: %v", err)
+	}
+
+	plan, resolvedManifest, err := buildPlan(&dynamicFlags{})
+	if err != nil {
+		t.Fatalf("buildPlan error: %v", err)
+	}
+	if resolvedManifest.Profile != "backend" {
+		t.Fatalf("expected discovered manifest profile backend, got %q", resolvedManifest.Profile)
+	}
+	if len(plan.Steps) == 0 {
+		t.Fatal("expected non-empty execution plan")
+	}
+}
+
+func TestBuildPlanNoManifestFallback(t *testing.T) {
+	tmp := t.TempDir()
+	prevWD, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	defer func() { _ = os.Chdir(prevWD) }()
+	if err := os.Chdir(tmp); err != nil {
+		t.Fatalf("chdir: %v", err)
+	}
+
+	plan, resolvedManifest, err := buildPlan(&dynamicFlags{})
+	if err != nil {
+		t.Fatalf("buildPlan error: %v", err)
+	}
+	if resolvedManifest.Profile != "" {
+		t.Fatalf("expected empty manifest profile fallback, got %q", resolvedManifest.Profile)
+	}
+	if len(plan.Steps) == 0 {
+		t.Fatal("expected fallback builtin plan")
+	}
+}
+
+func TestBuildPlanInvalidDiscoveredManifestReturnsError(t *testing.T) {
+	tmp := t.TempDir()
+	invalid := "apiVersion: v1\nprofiles:\n  bad: [\n"
+	if err := os.WriteFile(filepath.Join(tmp, "prepare.yaml"), []byte(invalid), 0o644); err != nil {
+		t.Fatalf("write manifest: %v", err)
+	}
+
+	prevWD, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	defer func() { _ = os.Chdir(prevWD) }()
+	if err := os.Chdir(tmp); err != nil {
+		t.Fatalf("chdir: %v", err)
+	}
+
+	_, _, err = buildPlan(&dynamicFlags{})
+	if err == nil {
+		t.Fatal("expected error for invalid discovered manifest")
+	}
+	if !strings.Contains(err.Error(), "unsupported manifest syntax") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}

--- a/internal/dynamic/catalog.go
+++ b/internal/dynamic/catalog.go
@@ -1,0 +1,137 @@
+package dynamic
+
+func BuiltinProfiles() map[string]Profile {
+	return map[string]Profile{
+		"base": {
+			Tools: []string{"homebrew", "git", "zsh", "vscode"},
+		},
+		"frontend": {
+			Extends: []string{"base"},
+			Tools:   []string{"nodejs"},
+		},
+		"backend": {
+			Extends: []string{"base"},
+			Tools:   []string{"go", "python", "docker"},
+		},
+		"data": {
+			Extends: []string{"base"},
+			Tools:   []string{"python", "docker"},
+		},
+		"ai": {
+			Extends: []string{"data"},
+			Tools:   []string{"dotnet"},
+		},
+		"fullstack": {
+			Extends: []string{"frontend", "backend"},
+			Tools:   []string{"dotnet", "iterm2"},
+		},
+	}
+}
+
+func BuiltinCatalog() map[string]ToolSpec {
+	return map[string]ToolSpec{
+		"homebrew": {
+			ID:          "homebrew",
+			Title:       "Homebrew",
+			Description: "Package manager for macOS",
+			Install: Command{
+				Name:  "/bin/bash",
+				Args:  []string{"-c", "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"},
+				Shell: "bash",
+			},
+			Check:   Check{Binary: "brew"},
+			Version: "latest",
+			Source:  "homebrew/homebrew-core",
+		},
+		"iterm2": {
+			ID:           "iterm2",
+			Title:        "iTerm2",
+			Description:  "Terminal emulator",
+			Dependencies: []string{"homebrew"},
+			Install:      Command{Name: "brew", Args: []string{"install", "--cask", "iterm2"}},
+			Check:        Check{PathExists: "/Applications/iTerm.app"},
+			Version:      "latest",
+			Source:       "homebrew/cask",
+		},
+		"zsh": {
+			ID:           "zsh",
+			Title:        "Zsh",
+			Description:  "Shell",
+			Dependencies: []string{"homebrew"},
+			Install:      Command{Name: "brew", Args: []string{"install", "zsh"}},
+			Check:        Check{Binary: "zsh"},
+			Version:      "latest",
+			Source:       "homebrew/homebrew-core",
+		},
+		"vscode": {
+			ID:           "vscode",
+			Title:        "Visual Studio Code",
+			Description:  "Code editor",
+			Dependencies: []string{"homebrew"},
+			Install:      Command{Name: "brew", Args: []string{"install", "--cask", "visual-studio-code"}},
+			Check:        Check{Binary: "code"},
+			Version:      "latest",
+			Source:       "homebrew/cask",
+		},
+		"git": {
+			ID:           "git",
+			Title:        "Git",
+			Description:  "Version control",
+			Dependencies: []string{"homebrew"},
+			Install:      Command{Name: "brew", Args: []string{"install", "git"}},
+			Check:        Check{Binary: "git"},
+			Version:      "latest",
+			Source:       "homebrew/homebrew-core",
+		},
+		"go": {
+			ID:           "go",
+			Title:        "Go",
+			Description:  "Go programming language",
+			Dependencies: []string{"homebrew"},
+			Install:      Command{Name: "brew", Args: []string{"install", "go"}},
+			Check:        Check{Binary: "go"},
+			Version:      "latest",
+			Source:       "homebrew/homebrew-core",
+		},
+		"nodejs": {
+			ID:           "nodejs",
+			Title:        "Node.js",
+			Description:  "Node.js LTS runtime",
+			Dependencies: []string{"homebrew"},
+			Install:      Command{Name: "brew", Args: []string{"install", "node"}},
+			Check:        Check{Binary: "node"},
+			Version:      "lts",
+			Source:       "homebrew/homebrew-core",
+		},
+		"dotnet": {
+			ID:           "dotnet",
+			Title:        ".NET SDK",
+			Description:  ".NET SDK",
+			Dependencies: []string{"homebrew"},
+			Install:      Command{Name: "brew", Args: []string{"install", "dotnet-sdk"}},
+			Check:        Check{Binary: "dotnet"},
+			Version:      "latest",
+			Source:       "homebrew/homebrew-core",
+		},
+		"python": {
+			ID:           "python",
+			Title:        "Python",
+			Description:  "Python runtime",
+			Dependencies: []string{"homebrew"},
+			Install:      Command{Name: "brew", Args: []string{"install", "python"}},
+			Check:        Check{Binary: "python3"},
+			Version:      "latest",
+			Source:       "homebrew/homebrew-core",
+		},
+		"docker": {
+			ID:           "docker",
+			Title:        "Docker",
+			Description:  "Container runtime",
+			Dependencies: []string{"homebrew"},
+			Install:      Command{Name: "brew", Args: []string{"install", "docker"}},
+			Check:        Check{Binary: "docker"},
+			Version:      "latest",
+			Source:       "homebrew/homebrew-core",
+		},
+	}
+}

--- a/internal/dynamic/executor.go
+++ b/internal/dynamic/executor.go
@@ -1,0 +1,140 @@
+package dynamic
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"runtime"
+	"time"
+)
+
+type ExecOptions struct {
+	DryRun    bool
+	Resume    bool
+	StatePath string
+}
+
+type commandRunner func(cmd Command) error
+
+type checker func(c Check) bool
+
+type Executor struct {
+	runCommand commandRunner
+	checkTool  checker
+}
+
+func NewExecutor() *Executor {
+	return &Executor{
+		runCommand: defaultCommandRunner,
+		checkTool:  defaultChecker,
+	}
+}
+
+func (e *Executor) Run(plan Plan, opts ExecOptions) (ExecutionResult, error) {
+	if err := preflight(); err != nil {
+		return ExecutionResult{}, err
+	}
+	if opts.StatePath == "" {
+		opts.StatePath = ".prepare.state.json"
+	}
+
+	state := State{Completed: map[string]bool{}}
+	var err error
+	if opts.Resume {
+		state, err = LoadState(opts.StatePath)
+		if err != nil {
+			return ExecutionResult{}, fmt.Errorf("load state: %w", err)
+		}
+	}
+
+	result := ExecutionResult{StartedAt: time.Now(), DryRun: opts.DryRun, Steps: []ExecutionStep{}}
+	for _, step := range plan.Steps {
+		stepStart := time.Now()
+		execStep := ExecutionStep{ToolID: step.Tool.ID, Success: true}
+
+		if state.Completed[step.Tool.ID] {
+			execStep.Action = "skip"
+			execStep.Reason = "already_completed"
+			execStep.DurationMs = time.Since(stepStart).Milliseconds()
+			result.Steps = append(result.Steps, execStep)
+			continue
+		}
+		if e.checkTool(step.Tool.Check) {
+			execStep.Action = "skip"
+			execStep.Reason = "already_installed"
+			execStep.DurationMs = time.Since(stepStart).Milliseconds()
+			result.Steps = append(result.Steps, execStep)
+			state.Completed[step.Tool.ID] = true
+			if opts.Resume {
+				if err := SaveState(opts.StatePath, state); err != nil {
+					return result, fmt.Errorf("save state: %w", err)
+				}
+			}
+			continue
+		}
+		if opts.DryRun {
+			execStep.Action = "install"
+			execStep.Reason = "dry_run"
+			execStep.DurationMs = time.Since(stepStart).Milliseconds()
+			result.Steps = append(result.Steps, execStep)
+			continue
+		}
+
+		execStep.Action = "install"
+		if err := e.runCommand(step.Tool.Install); err != nil {
+			execStep.Success = false
+			execStep.Error = err.Error()
+			execStep.DurationMs = time.Since(stepStart).Milliseconds()
+			result.Steps = append(result.Steps, execStep)
+			result.EndedAt = time.Now()
+			return result, fmt.Errorf("install %s: %w", step.Tool.ID, err)
+		}
+
+		state.Completed[step.Tool.ID] = true
+		if opts.Resume {
+			if err := SaveState(opts.StatePath, state); err != nil {
+				return result, fmt.Errorf("save state: %w", err)
+			}
+		}
+
+		execStep.DurationMs = time.Since(stepStart).Milliseconds()
+		result.Steps = append(result.Steps, execStep)
+	}
+
+	result.EndedAt = time.Now()
+	return result, nil
+}
+
+func preflight() error {
+	if runtime.GOOS != "darwin" {
+		return fmt.Errorf("unsupported OS: %s (macOS required)", runtime.GOOS)
+	}
+	return nil
+}
+
+func defaultCommandRunner(c Command) error {
+	var cmd *exec.Cmd
+	if c.Shell != "" {
+		cmd = exec.Command(c.Name, c.Args...)
+	} else {
+		cmd = exec.Command(c.Name, c.Args...)
+	}
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	return cmd.Run()
+}
+
+func defaultChecker(c Check) bool {
+	if c.Binary != "" {
+		_, err := exec.LookPath(c.Binary)
+		if err == nil {
+			return true
+		}
+	}
+	if c.PathExists != "" {
+		if _, err := os.Stat(c.PathExists); err == nil {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/dynamic/executor_test.go
+++ b/internal/dynamic/executor_test.go
@@ -1,0 +1,31 @@
+package dynamic
+
+import (
+	"runtime"
+	"testing"
+)
+
+func TestExecutorDryRunDoesNotExecuteCommand(t *testing.T) {
+	if runtime.GOOS != "darwin" {
+		t.Skip("preflight enforces darwin")
+	}
+	executor := NewExecutor()
+	called := false
+	executor.checkTool = func(c Check) bool { return false }
+	executor.runCommand = func(cmd Command) error {
+		called = true
+		return nil
+	}
+
+	plan := Plan{Steps: []PlanStep{{Order: 1, Tool: ToolSpec{ID: "git", Install: Command{Name: "echo"}}}}}
+	result, err := executor.Run(plan, ExecOptions{DryRun: true})
+	if err != nil {
+		t.Fatalf("Run error: %v", err)
+	}
+	if called {
+		t.Fatal("expected command runner not to be called in dry-run")
+	}
+	if len(result.Steps) != 1 || result.Steps[0].Reason != "dry_run" {
+		t.Fatalf("unexpected dry-run result: %#v", result.Steps)
+	}
+}

--- a/internal/dynamic/lockfile.go
+++ b/internal/dynamic/lockfile.go
@@ -1,0 +1,28 @@
+package dynamic
+
+import (
+	"sort"
+	"time"
+)
+
+func BuildLockfile(plan Plan) Lockfile {
+	tools := make([]LockedTool, 0, len(plan.Steps))
+	seen := map[string]bool{}
+	for _, step := range plan.Steps {
+		if seen[step.Tool.ID] {
+			continue
+		}
+		seen[step.Tool.ID] = true
+		tools = append(tools, LockedTool{
+			ID:      step.Tool.ID,
+			Version: step.Tool.Version,
+			Source:  step.Tool.Source,
+		})
+	}
+	sort.Slice(tools, func(i, j int) bool { return tools[i].ID < tools[j].ID })
+	return Lockfile{
+		Version:     1,
+		GeneratedAt: time.Now(),
+		Tools:       tools,
+	}
+}

--- a/internal/dynamic/manifest.go
+++ b/internal/dynamic/manifest.go
@@ -1,0 +1,261 @@
+package dynamic
+
+import (
+	"bufio"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+)
+
+func DiscoverManifestPath(explicitPath string) (string, error) {
+	if explicitPath != "" {
+		return explicitPath, nil
+	}
+	candidates := []string{"prepare.yaml", "prepare.yml", "prepare.json"}
+	for _, c := range candidates {
+		if _, err := os.Stat(c); err == nil {
+			return c, nil
+		}
+	}
+	return "", os.ErrNotExist
+}
+
+func LoadManifest(path string) (Manifest, error) {
+	b, err := os.ReadFile(path)
+	if err != nil {
+		return Manifest{}, err
+	}
+	trimmed := strings.TrimSpace(string(b))
+	if trimmed == "" {
+		return Manifest{APIVersion: "v1"}, nil
+	}
+	if strings.HasPrefix(trimmed, "{") {
+		var m Manifest
+		if err := json.Unmarshal([]byte(trimmed), &m); err != nil {
+			return Manifest{}, fmt.Errorf("invalid JSON manifest: %w", err)
+		}
+		if m.APIVersion == "" {
+			m.APIVersion = "v1"
+		}
+		if m.Profiles == nil {
+			m.Profiles = map[string]Profile{}
+		}
+		return m, nil
+	}
+	return parseYAMLManifest(trimmed)
+}
+
+func parseYAMLManifest(content string) (Manifest, error) {
+	m := Manifest{APIVersion: "v1", Profiles: map[string]Profile{}}
+	s := bufio.NewScanner(strings.NewReader(content))
+	var section string
+	var inProfile string
+	var profileField string
+	lineNo := 0
+
+	for s.Scan() {
+		lineNo++
+		raw := s.Text()
+		trimmed := strings.TrimSpace(stripComment(raw))
+		if trimmed == "" {
+			continue
+		}
+		indent := leadingSpaces(raw)
+
+		switch {
+		case indent == 0 && strings.HasPrefix(trimmed, "apiVersion:"):
+			m.APIVersion = strings.TrimSpace(strings.TrimPrefix(trimmed, "apiVersion:"))
+			section = ""
+			inProfile = ""
+		case indent == 0 && strings.HasPrefix(trimmed, "profile:"):
+			m.Profile = strings.TrimSpace(strings.TrimPrefix(trimmed, "profile:"))
+			section = ""
+			inProfile = ""
+		case indent == 0 && trimmed == "tools:":
+			section = "tools"
+			inProfile = ""
+		case indent == 0 && trimmed == "profiles:":
+			section = "profiles"
+			inProfile = ""
+		case section == "tools" && indent == 2 && strings.HasPrefix(trimmed, "- "):
+			m.Tools = append(m.Tools, strings.TrimSpace(strings.TrimPrefix(trimmed, "- ")))
+		case section == "profiles" && indent == 2 && strings.HasSuffix(trimmed, ":"):
+			inProfile = strings.TrimSuffix(trimmed, ":")
+			m.Profiles[inProfile] = m.Profiles[inProfile]
+			profileField = ""
+		case section == "profiles" && inProfile != "" && indent == 4 && strings.HasPrefix(trimmed, "tools:"):
+			profileField = "tools"
+		case section == "profiles" && inProfile != "" && indent == 4 && strings.HasPrefix(trimmed, "extends:"):
+			profileField = "extends"
+		case section == "profiles" && inProfile != "" && indent == 6 && strings.HasPrefix(trimmed, "- "):
+			p := m.Profiles[inProfile]
+			item := strings.TrimSpace(strings.TrimPrefix(trimmed, "- "))
+			if profileField == "tools" {
+				p.Tools = append(p.Tools, item)
+			} else if profileField == "extends" {
+				p.Extends = append(p.Extends, item)
+			} else {
+				return Manifest{}, fmt.Errorf("line %d: list item outside profile tools/extends", lineNo)
+			}
+			m.Profiles[inProfile] = p
+		default:
+			return Manifest{}, fmt.Errorf("line %d: unsupported manifest syntax", lineNo)
+		}
+	}
+	if err := s.Err(); err != nil {
+		return Manifest{}, err
+	}
+	return m, nil
+}
+
+func stripComment(s string) string {
+	if idx := strings.Index(s, "#"); idx >= 0 {
+		return s[:idx]
+	}
+	return s
+}
+
+func leadingSpaces(s string) int {
+	i := 0
+	for i < len(s) && s[i] == ' ' {
+		i++
+	}
+	return i
+}
+
+func ValidateManifest(m Manifest, catalog map[string]ToolSpec, builtinProfiles map[string]Profile) error {
+	if m.APIVersion == "" {
+		return errors.New("apiVersion is required")
+	}
+	if m.APIVersion != "v1" {
+		return fmt.Errorf("unsupported apiVersion %q", m.APIVersion)
+	}
+	for _, tool := range m.Tools {
+		if _, ok := catalog[tool]; !ok {
+			return fmt.Errorf("unknown tool %q", tool)
+		}
+	}
+
+	profiles := mergeProfiles(builtinProfiles, m.Profiles)
+	for profileName, profile := range profiles {
+		for _, base := range profile.Extends {
+			if _, ok := profiles[base]; !ok {
+				return fmt.Errorf("profile %q extends unknown profile %q", profileName, base)
+			}
+		}
+		for _, tool := range profile.Tools {
+			if _, ok := catalog[tool]; !ok {
+				return fmt.Errorf("profile %q references unknown tool %q", profileName, tool)
+			}
+		}
+	}
+
+	for name := range profiles {
+		if _, err := resolveProfile(name, profiles, nil, nil); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func ResolveTools(m Manifest, selectedProfile string, catalog map[string]ToolSpec, builtinProfiles map[string]Profile) ([]string, error) {
+	profiles := mergeProfiles(builtinProfiles, m.Profiles)
+	tools := append([]string{}, m.Tools...)
+
+	if selectedProfile == "" {
+		selectedProfile = m.Profile
+	}
+	if selectedProfile == "" {
+		selectedProfile = "fullstack"
+	}
+	if selectedProfile != "" {
+		resolved, err := resolveProfile(selectedProfile, profiles, nil, nil)
+		if err != nil {
+			return nil, err
+		}
+		tools = append(tools, resolved...)
+	}
+
+	tools = unique(tools)
+	for _, tool := range tools {
+		if _, ok := catalog[tool]; !ok {
+			return nil, fmt.Errorf("unknown tool %q", tool)
+		}
+	}
+	return tools, nil
+}
+
+func resolveProfile(name string, profiles map[string]Profile, visiting map[string]bool, visited map[string]bool) ([]string, error) {
+	if visiting == nil {
+		visiting = map[string]bool{}
+	}
+	if visited == nil {
+		visited = map[string]bool{}
+	}
+	if visiting[name] {
+		return nil, fmt.Errorf("profile inheritance cycle detected at %q", name)
+	}
+	if visited[name] {
+		return nil, nil
+	}
+	profile, ok := profiles[name]
+	if !ok {
+		return nil, fmt.Errorf("unknown profile %q", name)
+	}
+
+	visiting[name] = true
+	resolved := []string{}
+	for _, base := range profile.Extends {
+		baseTools, err := resolveProfile(base, profiles, visiting, visited)
+		if err != nil {
+			return nil, err
+		}
+		resolved = append(resolved, baseTools...)
+	}
+	resolved = append(resolved, profile.Tools...)
+	visiting[name] = false
+	visited[name] = true
+
+	return unique(resolved), nil
+}
+
+func mergeProfiles(builtin map[string]Profile, user map[string]Profile) map[string]Profile {
+	all := map[string]Profile{}
+	for k, v := range builtin {
+		all[k] = Profile{Extends: append([]string{}, v.Extends...), Tools: append([]string{}, v.Tools...)}
+	}
+	for k, v := range user {
+		all[k] = v
+	}
+	return all
+}
+
+func unique(values []string) []string {
+	seen := map[string]bool{}
+	out := make([]string, 0, len(values))
+	for _, v := range values {
+		if seen[v] {
+			continue
+		}
+		seen[v] = true
+		out = append(out, v)
+	}
+	return out
+}
+
+func FormatExampleManifestPath() string {
+	return filepath.Join(".", "prepare.yaml")
+}
+
+func SupportedProfiles(profiles map[string]Profile) []string {
+	out := make([]string, 0, len(profiles))
+	for k := range profiles {
+		out = append(out, k)
+	}
+	slices.Sort(out)
+	return out
+}

--- a/internal/dynamic/manifest_test.go
+++ b/internal/dynamic/manifest_test.go
@@ -1,0 +1,42 @@
+package dynamic
+
+import "testing"
+
+func TestResolveToolsWithProfileInheritance(t *testing.T) {
+	m := Manifest{
+		APIVersion: "v1",
+		Profile:    "custom",
+		Profiles: map[string]Profile{
+			"custom": {
+				Extends: []string{"backend"},
+				Tools:   []string{"nodejs"},
+			},
+		},
+	}
+	tools, err := ResolveTools(m, "", BuiltinCatalog(), BuiltinProfiles())
+	if err != nil {
+		t.Fatalf("ResolveTools error: %v", err)
+	}
+
+	expected := []string{"homebrew", "git", "zsh", "vscode", "go", "python", "docker", "nodejs"}
+	for _, want := range expected {
+		found := false
+		for _, got := range tools {
+			if got == want {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Fatalf("expected tool %q in resolved list %#v", want, tools)
+		}
+	}
+}
+
+func TestValidateManifestUnknownTool(t *testing.T) {
+	m := Manifest{APIVersion: "v1", Tools: []string{"not-real"}}
+	err := ValidateManifest(m, BuiltinCatalog(), BuiltinProfiles())
+	if err == nil {
+		t.Fatal("expected validation error for unknown tool")
+	}
+}

--- a/internal/dynamic/output.go
+++ b/internal/dynamic/output.go
@@ -1,0 +1,41 @@
+package dynamic
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+)
+
+func PrintJSON(v any) error {
+	enc := json.NewEncoder(os.Stdout)
+	enc.SetIndent("", "  ")
+	return enc.Encode(v)
+}
+
+func PrintPlanHuman(plan Plan) {
+	fmt.Printf("Execution plan (%d steps):\n", len(plan.Steps))
+	for _, step := range plan.Steps {
+		fmt.Printf("%d. %s (%s)\n", step.Order, step.Tool.Title, step.Tool.ID)
+	}
+}
+
+func PrintExecutionHuman(result ExecutionResult) {
+	fmt.Printf("Run summary: %d steps, dry-run=%v\n", len(result.Steps), result.DryRun)
+	for _, step := range result.Steps {
+		status := "ok"
+		if !step.Success {
+			status = "failed"
+		}
+		if step.Action == "skip" {
+			status = "skipped"
+		}
+		fmt.Printf("- %s: %s", step.ToolID, status)
+		if step.Reason != "" {
+			fmt.Printf(" (%s)", step.Reason)
+		}
+		if step.Error != "" {
+			fmt.Printf(" error=%s", step.Error)
+		}
+		fmt.Printf("\n")
+	}
+}

--- a/internal/dynamic/planner.go
+++ b/internal/dynamic/planner.go
@@ -1,0 +1,104 @@
+package dynamic
+
+import (
+	"fmt"
+	"sort"
+	"time"
+)
+
+func BuildPlan(toolIDs []string, catalog map[string]ToolSpec) (Plan, error) {
+	expanded := map[string]bool{}
+	visiting := map[string]bool{}
+	for _, id := range toolIDs {
+		if err := includeWithDependencies(id, catalog, expanded, visiting); err != nil {
+			return Plan{}, err
+		}
+	}
+
+	inDegree := map[string]int{}
+	graph := map[string][]string{}
+	expandedIDs := make([]string, 0, len(expanded))
+	for id := range expanded {
+		inDegree[id] = 0
+		expandedIDs = append(expandedIDs, id)
+	}
+	sort.Strings(expandedIDs)
+	for _, id := range expandedIDs {
+		for _, dep := range catalog[id].Dependencies {
+			if !expanded[dep] {
+				continue
+			}
+			graph[dep] = append(graph[dep], id)
+			inDegree[id]++
+		}
+	}
+
+	queue := []string{}
+	for _, requested := range toolIDs {
+		if inDegree[requested] == 0 && expanded[requested] {
+			queue = appendUnique(queue, requested)
+		}
+	}
+	for _, id := range expandedIDs {
+		if inDegree[id] == 0 {
+			queue = appendUnique(queue, id)
+		}
+	}
+
+	ordered := []string{}
+	for len(queue) > 0 {
+		node := queue[0]
+		queue = queue[1:]
+		ordered = append(ordered, node)
+		sort.Strings(graph[node])
+		for _, next := range graph[node] {
+			inDegree[next]--
+			if inDegree[next] == 0 {
+				queue = append(queue, next)
+			}
+		}
+		sort.Strings(queue)
+	}
+
+	if len(ordered) != len(expanded) {
+		return Plan{}, fmt.Errorf("dependency cycle detected while building execution plan")
+	}
+
+	steps := make([]PlanStep, 0, len(ordered))
+	for idx, id := range ordered {
+		steps = append(steps, PlanStep{Order: idx + 1, Tool: catalog[id]})
+	}
+
+	return Plan{CreatedAt: time.Now(), Steps: steps}, nil
+}
+
+func includeWithDependencies(id string, catalog map[string]ToolSpec, out map[string]bool, visiting map[string]bool) error {
+	if out[id] {
+		return nil
+	}
+	if visiting[id] {
+		return fmt.Errorf("dependency cycle detected at tool %q", id)
+	}
+	spec, ok := catalog[id]
+	if !ok {
+		return fmt.Errorf("unknown tool %q", id)
+	}
+	visiting[id] = true
+	for _, dep := range spec.Dependencies {
+		if err := includeWithDependencies(dep, catalog, out, visiting); err != nil {
+			return err
+		}
+	}
+	delete(visiting, id)
+	out[id] = true
+	return nil
+}
+
+func appendUnique(values []string, value string) []string {
+	for _, v := range values {
+		if v == value {
+			return values
+		}
+	}
+	return append(values, value)
+}

--- a/internal/dynamic/planner_test.go
+++ b/internal/dynamic/planner_test.go
@@ -1,0 +1,30 @@
+package dynamic
+
+import "testing"
+
+func TestBuildPlanResolvesDependenciesFirst(t *testing.T) {
+	plan, err := BuildPlan([]string{"docker"}, BuiltinCatalog())
+	if err != nil {
+		t.Fatalf("BuildPlan error: %v", err)
+	}
+	if len(plan.Steps) < 2 {
+		t.Fatalf("expected at least 2 steps, got %d", len(plan.Steps))
+	}
+	if plan.Steps[0].Tool.ID != "homebrew" {
+		t.Fatalf("expected homebrew first, got %s", plan.Steps[0].Tool.ID)
+	}
+	if plan.Steps[len(plan.Steps)-1].Tool.ID != "docker" {
+		t.Fatalf("expected docker last, got %s", plan.Steps[len(plan.Steps)-1].Tool.ID)
+	}
+}
+
+func TestBuildPlanCycleDetection(t *testing.T) {
+	catalog := map[string]ToolSpec{
+		"a": {ID: "a", Dependencies: []string{"b"}},
+		"b": {ID: "b", Dependencies: []string{"a"}},
+	}
+	_, err := BuildPlan([]string{"a"}, catalog)
+	if err == nil {
+		t.Fatal("expected cycle detection error")
+	}
+}

--- a/internal/dynamic/state.go
+++ b/internal/dynamic/state.go
@@ -1,0 +1,33 @@
+package dynamic
+
+import (
+	"encoding/json"
+	"errors"
+	"os"
+)
+
+func LoadState(path string) (State, error) {
+	b, err := os.ReadFile(path)
+	if errors.Is(err, os.ErrNotExist) {
+		return State{Completed: map[string]bool{}}, nil
+	}
+	if err != nil {
+		return State{}, err
+	}
+	var s State
+	if err := json.Unmarshal(b, &s); err != nil {
+		return State{}, err
+	}
+	if s.Completed == nil {
+		s.Completed = map[string]bool{}
+	}
+	return s, nil
+}
+
+func SaveState(path string, state State) error {
+	b, err := json.MarshalIndent(state, "", "  ")
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(path, b, 0o644)
+}

--- a/internal/dynamic/types.go
+++ b/internal/dynamic/types.go
@@ -1,0 +1,79 @@
+package dynamic
+
+import "time"
+
+type Manifest struct {
+	APIVersion string             `json:"apiVersion"`
+	Profile    string             `json:"profile,omitempty"`
+	Tools      []string           `json:"tools,omitempty"`
+	Profiles   map[string]Profile `json:"profiles,omitempty"`
+}
+
+type Profile struct {
+	Extends []string `json:"extends,omitempty"`
+	Tools   []string `json:"tools,omitempty"`
+}
+
+type ToolSpec struct {
+	ID           string   `json:"id"`
+	Title        string   `json:"title"`
+	Description  string   `json:"description"`
+	Dependencies []string `json:"dependencies,omitempty"`
+	Install      Command  `json:"install"`
+	Check        Check    `json:"check"`
+	Version      string   `json:"version,omitempty"`
+	Source       string   `json:"source,omitempty"`
+}
+
+type Command struct {
+	Name  string   `json:"name"`
+	Args  []string `json:"args,omitempty"`
+	Shell string   `json:"shell,omitempty"`
+}
+
+type Check struct {
+	Binary     string `json:"binary,omitempty"`
+	PathExists string `json:"pathExists,omitempty"`
+}
+
+type Plan struct {
+	CreatedAt time.Time  `json:"createdAt"`
+	Steps     []PlanStep `json:"steps"`
+}
+
+type PlanStep struct {
+	Order int      `json:"order"`
+	Tool  ToolSpec `json:"tool"`
+}
+
+type ExecutionResult struct {
+	StartedAt time.Time       `json:"startedAt"`
+	EndedAt   time.Time       `json:"endedAt"`
+	DryRun    bool            `json:"dryRun"`
+	Steps     []ExecutionStep `json:"steps"`
+}
+
+type ExecutionStep struct {
+	ToolID     string `json:"toolId"`
+	Action     string `json:"action"`
+	Reason     string `json:"reason,omitempty"`
+	Success    bool   `json:"success"`
+	Error      string `json:"error,omitempty"`
+	DurationMs int64  `json:"durationMs"`
+}
+
+type State struct {
+	Completed map[string]bool `json:"completed"`
+}
+
+type Lockfile struct {
+	Version     int          `json:"version"`
+	GeneratedAt time.Time    `json:"generatedAt"`
+	Tools       []LockedTool `json:"tools"`
+}
+
+type LockedTool struct {
+	ID      string `json:"id"`
+	Version string `json:"version,omitempty"`
+	Source  string `json:"source,omitempty"`
+}


### PR DESCRIPTION
## Summary
- add a dynamic execution engine with manifest parsing, profile inheritance, dependency planning, and idempotent execution
- add CLI commands: `plan`, `run`, `lint`, and `lock` with `--dry-run`, `--json`, `--resume`, and state path support
- keep existing interactive installer flow (`prepare`) unchanged for backward compatibility
- add tests for manifest resolution, planner ordering/cycle detection, and dry-run executor behavior

## Architecture Summary
- **Manifest layer**: loads `prepare.yaml|yml|json`, validates schema constraints, merges builtin + user profiles, resolves inheritance
- **Planner layer**: expands dependencies and builds a deterministic topological order
- **Executor layer**: preflight macOS check, idempotency checks (`already_installed`/`already_completed`), dry-run semantics, checkpoint/resume state
- **Output layer**: human output plus structured JSON for automation
- **Lock strategy**: generate `prepare.lock.json` with tool id/version/source from resolved plan

## Migration Notes
- `prepare` without subcommands still runs the legacy interactive prompt
- new declarative workflows are additive under `prepare plan|run|lint|lock`
- existing `cmd/install/*` installers remain intact

## Validation
- `go test ./...`
- `go run . plan --profile frontend`
- `go run . run --profile backend --dry-run --json`
- `go run . plan --file /tmp/prepare-sample.yaml`

## Follow-up Gaps
- YAML parsing is intentionally minimal and could be replaced by full YAML v3 decoding for broader syntax support
- lockfile currently captures catalog metadata; exact installed versions can be added in a future pass
- planner currently executes sequentially; parallel execution with safe dependency barriers can be added later